### PR TITLE
Refactor Ontology and Utils

### DIFF
--- a/src/main/java/msz/bakk/cmd/CmdApplication.java
+++ b/src/main/java/msz/bakk/cmd/CmdApplication.java
@@ -9,6 +9,9 @@ import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.shell.jline.PromptProvider;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+
 
 @TestConfiguration
 // https://stackoverflow.com/a/52224897

--- a/src/main/java/msz/bakk/cmd/RDFMessages.java
+++ b/src/main/java/msz/bakk/cmd/RDFMessages.java
@@ -3,12 +3,12 @@ package msz.bakk.cmd;
 import msz.bakk.protocol.Message.Certificate;
 import msz.bakk.protocol.Message.Reputationtoken;
 import msz.bakk.protocol.Utils.MessageUtils;
+import msz.bakk.protocol.util.WonRepRdfUtils;
+import msz.bakk.protocol.vocabulary.REP;
 import org.apache.jena.rdf.model.Model;
 import org.apache.jena.rdf.model.Resource;
 import won.protocol.message.WonMessage;
 import won.protocol.message.WonMessageBuilder;
-import won.protocol.util.WonRepRdfUtils;
-import won.protocol.vocabulary.REP;
 
 import java.net.URI;
 import java.security.NoSuchAlgorithmException;

--- a/src/main/java/msz/bakk/protocol/util/WonRepRdfUtils.java
+++ b/src/main/java/msz/bakk/protocol/util/WonRepRdfUtils.java
@@ -1,0 +1,32 @@
+package msz.bakk.protocol.util;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.slf4j.LoggerFactory;
+import won.protocol.util.WonRdfUtils;
+
+import java.util.logging.Logger;
+
+public class WonRepRdfUtils extends WonRdfUtils {
+    private static final Logger logger = (Logger) LoggerFactory.getLogger(WonRepRdfUtils.class);
+
+    public static Model addStuff(Model model) {
+        // Model messageModel = createModelWithBaseResource();
+        // Resource baseRes =
+        // messageModel.createResource(messageModel.getNsPrefixURI(""));
+        // baseRes.addProperty(WONCON.text, message, XSDDatatype.XSDstring);
+        // return messageModel;
+        return null;
+    }
+
+    public static Model createBaseModel() {
+        return createModelWithBaseResource();
+    }
+
+    private static Model createModelWithBaseResource() {
+        Model model = ModelFactory.createDefaultModel();
+        model.setNsPrefix("", "no:uri");
+        model.createResource(model.getNsPrefixURI(""));
+        return model;
+    }
+}

--- a/src/main/java/msz/bakk/protocol/vocabulary/REP.java
+++ b/src/main/java/msz/bakk/protocol/vocabulary/REP.java
@@ -1,0 +1,22 @@
+package msz.bakk.protocol.vocabulary;
+
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.rdf.model.Property;
+
+public class REP {
+    public static final String BASE_URI = "https://w3id.org/won/ext/reputation#";
+    public static final String DEFAULT_PREFIX = "srep";
+    private static Model m = ModelFactory.createDefaultModel();
+    public static final Property CERTIFICATE = m.createProperty(BASE_URI + " certificate");
+    public static final Property USER_ID = m.createProperty(BASE_URI + " userId");
+    public static final Property PUBLIC_KEY = m.createProperty(BASE_URI + " publicKey");
+    public static final Property REPUTATIONTOKEN = m.createProperty(BASE_URI + "ReputationToken");
+    public static final Property BLIND_SIGNED_REPUTATIONTOKEN = m
+            .createProperty(BASE_URI + "blindSignedReputationToken");
+    public static final Property RATING = m.createProperty(BASE_URI + "rating");
+    public static final Property RATING_COMMENT = m.createProperty(BASE_URI + "ratingComment");
+    public static final Property RANDOM_HASH = m.createProperty(BASE_URI + "RandomHash");
+    public static final Property SIGNED_RANDOM_HASH = m.createProperty(BASE_URI + "signedRandomHash");
+    public static final Property VERIFICATION_STATE = m.createProperty(BASE_URI + "verificationState");
+}


### PR DESCRIPTION
Moved the Ontology from our base project directly into this one, that way you are not dependent on a special web-of-needs fork and can use the current master

These changes might become obsolete if we decide to move your ontology/utils directly into our project, but for now it is valid to implement them solely in this repository